### PR TITLE
Consolidate Renovate config: weekly schedule, 7-day cooldown, security bypass

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,10 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:best-practices"]
+	"extends": ["config:best-practices", "schedule:weekly"],
+	"minimumReleaseAge": "7 days",
+	"osvVulnerabilityAlerts": true,
+	"vulnerabilityAlerts": {
+		"schedule": ["at any time"],
+		"minimumReleaseAge": null
+	}
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,3 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:best-practices", "schedule:weekly"],
-	"minimumReleaseAge": "7 days",
-	"osvVulnerabilityAlerts": true,
-	"vulnerabilityAlerts": {
-		"schedule": ["at any time"],
-		"minimumReleaseAge": null
-	}
+	"extends": ["github>pl4nty/.github"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
Reduces Renovate PR noise on this repo and serves as the template for centralising the same settings across other repos.

## Changes

- **Removed the duplicate root `renovate.json`** — Renovate reads the root file first, so the existing `.github/renovate.json` (`config:best-practices`) was silently ignored and only `config:recommended` was active. There is now a single config in `.github/renovate.json`.
- **`schedule:weekly`** — regular update PRs are only created in a weekly window (before 4am Monday), so updates arrive as one weekly batch instead of trickling in all week.
- **`minimumReleaseAge: "7 days"`** — a cooldown: new releases must be at least a week old before Renovate proposes them, avoiding day-one broken/unpublished releases.
- **Security bypass** — `vulnerabilityAlerts` is configured with `"schedule": ["at any time"]` and `minimumReleaseAge: null`, so PRs fixing known vulnerabilities skip both the weekly window and the cooldown. `osvVulnerabilityAlerts: true` adds OSV-database coverage on top of GitHub's vulnerability alerts.

## Centralising across repos

To apply these settings to many repos, move this config (minus `$schema`) into a `pl4nty/renovate-config` repo — either as `org-inherited-config.json` (auto-applied by the Mend Renovate app, zero per-repo changes) or as `default.json` extended via `"extends": ["github>pl4nty/renovate-config"]` in each repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkbVR6AWMJA4pJGMjmHvL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkbVR6AWMJA4pJGMjmHvL3)_