### PR TITLE
Show per-element registry key and value name on policy pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,31 +45,6 @@ jobs:
         env:
           NODE_ENV: production
 
-      # The build emits root-absolute URLs (/_astro/..., /data/...), hydrates via
-      # ES modules and fetches /data/*.json at runtime, so opening index.html over
-      # file:// can never work — assets resolve against the filesystem root and the
-      # null origin blocks both module scripts and fetch. Ship the how-to-serve
-      # note inside the artifact, where someone who hit a blank page will look.
-      - name: Add serve instructions to build output
-        run: |
-          cat > dist/README.md <<'EOF'
-          # Previewing this build
-
-          This is a static site, but it must be served over HTTP — opening
-          `index.html` directly from disk (`file://`) will show a blank or broken
-          page, because the asset URLs are absolute, the scripts are ES modules,
-          and the sidebar/search fetch JSON at runtime. All three are blocked
-          under `file://`.
-
-          From this folder, run whichever you have:
-
-              npx serve .
-              python3 -m http.server 4321
-              php -S localhost:4321
-
-          Then open the URL it prints (e.g. <http://localhost:4321/en-us/>).
-          EOF
-
       - name: Upload built site
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -123,7 +98,7 @@ jobs:
               'The site built successfully. Download the artifacts from this run to preview the changes:',
               '',
               `- 📸 [**Screenshots**](${runUrl}) — \`home.png\` and \`policy.png\` artifacts`,
-              `- 🌐 [**Built site**](${runUrl}) — \`dist\` artifact. Unzip it and serve it over HTTP (\`npx serve .\` or \`python3 -m http.server 4321\`), then open <http://localhost:4321/en-us/>. Opening \`index.html\` straight from disk won't work — see the \`README.md\` in the artifact.`,
+              `- 🌐 [**Built site**](${runUrl}) — \`dist\` artifact. Unzip it and serve it over HTTP (\`npx serve .\` or \`python3 -m http.server 4321\`), then open <http://localhost:4321/en-us/>.`,
               '',
               `<sub>Updated for commit ${context.sha.slice(0, 7)} · [view run](${runUrl})</sub>`,
             ].join('\n');

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,31 @@ jobs:
         env:
           NODE_ENV: production
 
+      # The build emits root-absolute URLs (/_astro/..., /data/...), hydrates via
+      # ES modules and fetches /data/*.json at runtime, so opening index.html over
+      # file:// can never work — assets resolve against the filesystem root and the
+      # null origin blocks both module scripts and fetch. Ship the how-to-serve
+      # note inside the artifact, where someone who hit a blank page will look.
+      - name: Add serve instructions to build output
+        run: |
+          cat > dist/README.md <<'EOF'
+          # Previewing this build
+
+          This is a static site, but it must be served over HTTP — opening
+          `index.html` directly from disk (`file://`) will show a blank or broken
+          page, because the asset URLs are absolute, the scripts are ES modules,
+          and the sidebar/search fetch JSON at runtime. All three are blocked
+          under `file://`.
+
+          From this folder, run whichever you have:
+
+              npx serve .
+              python3 -m http.server 4321
+              php -S localhost:4321
+
+          Then open the URL it prints (e.g. <http://localhost:4321/en-us/>).
+          EOF
+
       - name: Upload built site
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -98,7 +123,7 @@ jobs:
               'The site built successfully. Download the artifacts from this run to preview the changes:',
               '',
               `- 📸 [**Screenshots**](${runUrl}) — \`home.png\` and \`policy.png\` artifacts`,
-              `- 🌐 [**Built site**](${runUrl}) — \`dist\` artifact (open \`index.html\` or serve locally for a live preview)`,
+              `- 🌐 [**Built site**](${runUrl}) — \`dist\` artifact. Unzip it and serve it over HTTP (\`npx serve .\` or \`python3 -m http.server 4321\`), then open <http://localhost:4321/en-us/>. Opening \`index.html\` straight from disk won't work — see the \`README.md\` in the artifact.`,
               '',
               `<sub>Updated for commit ${context.sha.slice(0, 7)} · [view run](${runUrl})</sub>`,
             ].join('\n');

--- a/src/components/RegistryValues.astro
+++ b/src/components/RegistryValues.astro
@@ -1,0 +1,26 @@
+---
+import { formatPolicyValue, registryPath } from '@/policyFormat';
+
+interface Props {
+  label: string;
+  items: any[];
+  fallbackKey?: string;
+}
+
+const { label, items = [], fallbackKey = '' } = Astro.props;
+---
+
+{items.length > 0 && (
+  <div>
+    <div class="font-medium text-gray-700 dark:text-gray-200">{label}</div>
+    <ul class="mt-1 space-y-1">
+      {items.map((item: any) => (
+        <li class="text-sm flex flex-wrap items-baseline gap-x-2">
+          <span class="font-mono break-all text-gray-900 dark:text-white">{registryPath(item.key || fallbackKey, item.valueName)}</span>
+          <span class="text-gray-400 dark:text-gray-500">=</span>
+          <span class="font-mono text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700">{formatPolicyValue(item.value)}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+)}

--- a/src/loaders/admxPolicyLoader.ts
+++ b/src/loaders/admxPolicyLoader.ts
@@ -213,6 +213,7 @@ export function admxPolicyLoader(): Loader {
               parentCategory: pol.parentCategory || '', categoryPath: pol.categoryPath || [],
               elements: pol.elements || [], presentationElements: pol.presentationElements || [],
               enabledValue: pol.enabledValue || null, disabledValue: pol.disabledValue || null,
+              enabledList: pol.enabledList || null, disabledList: pol.disabledList || null,
               csp: pol.csp || null, catalog: pol.catalog || null, downloadUrl: pol.downloadUrl || null,
               namespace, fileSlug: slug, lang: langKey, availableLangs,
             })

--- a/src/pages/[lang]/policy/[...slug].astro
+++ b/src/pages/[lang]/policy/[...slug].astro
@@ -1,5 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
+import RegistryValues from '@/components/RegistryValues.astro';
+import { formatPolicyValue, registryPath, describeListValueNames } from '@/policyFormat';
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -37,10 +39,14 @@ const presentationNotes = (policy.presentationElements || []).filter(
   (el: any) => el?.type === 'text' && el?.label && !el?.refId
 )
 const hasElements = policy.elements?.length > 0
-const hasExplicitValues = Boolean(policy.enabledValue || policy.disabledValue)
+const enabledList = policy.enabledList || []
+const disabledList = policy.disabledList || []
+const hasExplicitValues = Boolean(policy.enabledValue || policy.disabledValue || enabledList.length || disabledList.length)
 const showStateFallback = !hasElements && !hasExplicitValues && (policy.key || policy.valueName)
 
-const fmtVal = (val: any) => !val ? 'Not set' : val.type === 'decimal' ? String(val.value) : val.type === 'string' ? String(val.value || '') : val.type === 'delete' ? 'Delete value' : String(val)
+const fmtVal = formatPolicyValue
+// Elements may override the policy's key; when they don't, they write under it.
+const elemKey = (elem: any) => elem?.key || policy.key || ''
 const elemLabel = (elem: any) => presentationByRef.get(elem?.id)?.label || elem?.label || elem?.id || 'Value'
 const elemDefault = (elem: any) => { const pres = presentationByRef.get(elem?.id); return pres?.defaultValue != null ? String(pres.defaultValue) : null }
 const linkify = (text: string) => String(text || '').replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" style="color:#0ea5e9;text-decoration:underline;text-underline-offset:2px;" target="_blank" rel="noopener noreferrer">$1</a>')
@@ -122,12 +128,14 @@ const linkify = (text: string) => String(text || '').replace(/(https?:\/\/[^\s<]
           )
         })()}
 
-        {(policy.enabledValue || policy.disabledValue) && (
+        {hasExplicitValues && (
           <div class="md:col-span-2">
             <dt class="font-medium text-gray-500 dark:text-gray-400">Policy State Values</dt>
-            <dd class="text-sm text-gray-700 dark:text-gray-300">
+            <dd class="text-sm text-gray-700 dark:text-gray-300 space-y-2">
               {policy.enabledValue && <div>Enabled: <span class="font-mono">{fmtVal(policy.enabledValue)}</span></div>}
               {policy.disabledValue && <div>Disabled: <span class="font-mono">{fmtVal(policy.disabledValue)}</span></div>}
+              <RegistryValues label="Enabled writes" items={enabledList} fallbackKey={policy.key} />
+              <RegistryValues label="Disabled writes" items={disabledList} fallbackKey={policy.key} />
             </dd>
           </div>
         )}
@@ -159,7 +167,22 @@ const linkify = (text: string) => String(text || '').replace(/(https?:\/\/[^\s<]
           {policy.elements.map((elem: any) => (
             <div class="border-t border-gray-200 dark:border-gray-700 pt-4 first:border-t-0 first:pt-0">
               <h3 class="font-medium text-gray-900 dark:text-white mb-1 break-words">{elemLabel(elem)}</h3>
+
+              {elemKey(elem) && (
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                  Registry Key: <span class="font-mono text-gray-900 dark:text-white break-all">{elemKey(elem)}</span>
+                  {elem.key && policy.key && elem.key !== policy.key && <span class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">differs from policy key</span>}
+                </p>
+              )}
+              {elem.valueName
+                ? <p class="text-sm text-gray-500 dark:text-gray-400">Value Name: <span class="font-mono text-gray-900 dark:text-white break-all">{elem.valueName}</span></p>
+                : elem.type === 'list' && <p class="text-sm text-gray-500 dark:text-gray-400">{describeListValueNames(elem)}</p>}
+              {elem.valueName && elemKey(elem) && (
+                <p class="text-sm text-gray-500 dark:text-gray-400">Full Path: <span class="font-mono text-gray-900 dark:text-white break-all">{registryPath(elemKey(elem), elem.valueName)}</span></p>
+              )}
+
               {elem.type && <p class="text-sm text-gray-500 dark:text-gray-400">Type: <span class="font-mono">{elem.type}</span></p>}
+              {elem.required !== undefined && <p class="text-sm text-gray-500 dark:text-gray-400">Required: <span class="font-mono">{String(elem.required)}</span></p>}
               {elemDefault(elem) && <p class="text-sm text-gray-500 dark:text-gray-400">Default: <span class="font-mono">{elemDefault(elem)}</span></p>}
 
               {elem.type === 'enum' && elem.items?.length > 0 && (
@@ -176,9 +199,15 @@ const linkify = (text: string) => String(text || '').replace(/(https?:\/\/[^\s<]
                 </div>
               )}
               {elem.type === 'boolean' && (
-                <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                  <div class="flex flex-wrap gap-2"><span class="font-medium">True:</span><span class="font-mono">{fmtVal(elem.trueValue)}</span></div>
-                  <div class="flex flex-wrap gap-2"><span class="font-medium">False:</span><span class="font-mono">{fmtVal(elem.falseValue)}</span></div>
+                <div class="mt-2 text-sm text-gray-600 dark:text-gray-300 space-y-2">
+                  {(elem.trueValue || elem.falseValue || (!elem.trueList?.length && !elem.falseList?.length)) && (
+                    <div>
+                      <div class="flex flex-wrap gap-2"><span class="font-medium">True:</span><span class="font-mono">{fmtVal(elem.trueValue)}</span></div>
+                      <div class="flex flex-wrap gap-2"><span class="font-medium">False:</span><span class="font-mono">{fmtVal(elem.falseValue)}</span></div>
+                    </div>
+                  )}
+                  <RegistryValues label="True writes" items={elem.trueList || []} fallbackKey={elemKey(elem)} />
+                  <RegistryValues label="False writes" items={elem.falseList || []} fallbackKey={elemKey(elem)} />
                 </div>
               )}
               {(elem.type === 'decimal' || elem.type === 'longDecimal') && (

--- a/src/pages/[lang]/policy/[...slug].astro
+++ b/src/pages/[lang]/policy/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import RegistryValues from '@/components/RegistryValues.astro';
-import { formatPolicyValue, registryPath, describeListValueNames } from '@/policyFormat';
+import { formatPolicyValue, describeListValueNames } from '@/policyFormat';
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -168,22 +168,20 @@ const linkify = (text: string) => String(text || '').replace(/(https?:\/\/[^\s<]
             <div class="border-t border-gray-200 dark:border-gray-700 pt-4 first:border-t-0 first:pt-0">
               <h3 class="font-medium text-gray-900 dark:text-white mb-1 break-words">{elemLabel(elem)}</h3>
 
-              {elemKey(elem) && (
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                  Registry Key: <span class="font-mono text-gray-900 dark:text-white break-all">{elemKey(elem)}</span>
-                  {elem.key && policy.key && elem.key !== policy.key && <span class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">differs from policy key</span>}
-                </p>
-              )}
-              {elem.valueName
-                ? <p class="text-sm text-gray-500 dark:text-gray-400">Value Name: <span class="font-mono text-gray-900 dark:text-white break-all">{elem.valueName}</span></p>
-                : elem.type === 'list' && <p class="text-sm text-gray-500 dark:text-gray-400">{describeListValueNames(elem)}</p>}
-              {elem.valueName && elemKey(elem) && (
-                <p class="text-sm text-gray-500 dark:text-gray-400">Full Path: <span class="font-mono text-gray-900 dark:text-white break-all">{registryPath(elemKey(elem), elem.valueName)}</span></p>
-              )}
-
-              {elem.type && <p class="text-sm text-gray-500 dark:text-gray-400">Type: <span class="font-mono">{elem.type}</span></p>}
-              {elem.required !== undefined && <p class="text-sm text-gray-500 dark:text-gray-400">Required: <span class="font-mono">{String(elem.required)}</span></p>}
-              {elemDefault(elem) && <p class="text-sm text-gray-500 dark:text-gray-400">Default: <span class="font-mono">{elemDefault(elem)}</span></p>}
+              <div class="space-y-1.5">
+                {elemKey(elem) && (
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
+                    Registry Key: <span class="font-mono text-gray-900 dark:text-white break-all">{elemKey(elem)}</span>
+                    {elem.key && policy.key && elem.key !== policy.key && <span class="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">differs from policy key</span>}
+                  </p>
+                )}
+                {elem.valueName
+                  ? <p class="text-sm text-gray-500 dark:text-gray-400">Value Name: <span class="font-mono text-gray-900 dark:text-white break-all">{elem.valueName}</span></p>
+                  : elem.type === 'list' && <p class="text-sm text-gray-500 dark:text-gray-400">{describeListValueNames(elem)}</p>}
+                {elem.type && <p class="text-sm text-gray-500 dark:text-gray-400">Type: <span class="font-mono">{elem.type}</span></p>}
+                {elem.required !== undefined && <p class="text-sm text-gray-500 dark:text-gray-400">Required: <span class="font-mono">{String(elem.required)}</span></p>}
+                {elemDefault(elem) && <p class="text-sm text-gray-500 dark:text-gray-400">Default: <span class="font-mono">{elemDefault(elem)}</span></p>}
+              </div>
 
               {elem.type === 'enum' && elem.items?.length > 0 && (
                 <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
@@ -201,7 +199,7 @@ const linkify = (text: string) => String(text || '').replace(/(https?:\/\/[^\s<]
               {elem.type === 'boolean' && (
                 <div class="mt-2 text-sm text-gray-600 dark:text-gray-300 space-y-2">
                   {(elem.trueValue || elem.falseValue || (!elem.trueList?.length && !elem.falseList?.length)) && (
-                    <div>
+                    <div class="space-y-1.5">
                       <div class="flex flex-wrap gap-2"><span class="font-medium">True:</span><span class="font-mono">{fmtVal(elem.trueValue)}</span></div>
                       <div class="flex flex-wrap gap-2"><span class="font-medium">False:</span><span class="font-mono">{fmtVal(elem.falseValue)}</span></div>
                     </div>
@@ -211,19 +209,19 @@ const linkify = (text: string) => String(text || '').replace(/(https?:\/\/[^\s<]
                 </div>
               )}
               {(elem.type === 'decimal' || elem.type === 'longDecimal') && (
-                <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                <div class="mt-1.5 space-y-1.5 text-sm text-gray-600 dark:text-gray-300">
                   {elem.minValue !== undefined && <div>Min: <span class="font-mono">{elem.minValue}</span></div>}
                   {elem.maxValue !== undefined && <div>Max: <span class="font-mono">{elem.maxValue}</span></div>}
                 </div>
               )}
               {(elem.type === 'text' || elem.type === 'multiText') && (
-                <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                <div class="mt-1.5 space-y-1.5 text-sm text-gray-600 dark:text-gray-300">
                   {elem.maxLength !== undefined && <div>Max length: <span class="font-mono">{elem.maxLength}</span></div>}
                   {elem.expandable !== undefined && <div>Expandable: <span class="font-mono">{String(elem.expandable)}</span></div>}
                 </div>
               )}
               {elem.type === 'list' && (
-                <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                <div class="mt-1.5 space-y-1.5 text-sm text-gray-600 dark:text-gray-300">
                   {elem.explicitValue !== undefined && <div>Explicit values: <span class="font-mono">{String(elem.explicitValue)}</span></div>}
                   {elem.additive !== undefined && <div>Additive: <span class="font-mono">{String(elem.additive)}</span></div>}
                   {elem.valuePrefix && <div>Value prefix: <span class="font-mono">{elem.valuePrefix}</span></div>}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -47,9 +47,12 @@ function resolvePresentationRef(ref: string | undefined, presentations: Record<s
 
 function parseValue(node: any): PolicyValue | null {
   if (!node) return null
-  if (node.decimal) return { type: 'decimal', value: parseInt(node.decimal.value) }
-  if (node.string) return { type: 'string', value: node.string._text || node.string || '' }
-  if (node.delete) return { type: 'delete' }
+  // Self-closing tags parse to '', so test for presence rather than truthiness —
+  // <delete /> and <string /> are both meaningful but falsy.
+  if (node.decimal !== undefined) return { type: 'decimal', value: parseInt(node.decimal?.value) }
+  if (node.longDecimal !== undefined) return { type: 'decimal', value: parseInt(node.longDecimal?.value) }
+  if (node.string !== undefined) return { type: 'string', value: node.string?._text ?? (typeof node.string === 'string' ? node.string : '') }
+  if (node.delete !== undefined) return { type: 'delete' }
   return null
 }
 

--- a/src/policyFormat.test.ts
+++ b/src/policyFormat.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { formatPolicyValue, registryPath, describeListValueNames } from './policyFormat'
+import { parseAdmx } from './parser'
+
+describe('formatPolicyValue', () => {
+  it('formats decimal, string and delete values', () => {
+    expect(formatPolicyValue({ type: 'decimal', value: 1 })).toBe('1')
+    expect(formatPolicyValue({ type: 'string', value: 'abc' })).toBe('abc')
+    expect(formatPolicyValue({ type: 'delete' })).toBe('Delete value')
+  })
+
+  it('renders an empty string value as empty, not as unset', () => {
+    expect(formatPolicyValue({ type: 'string', value: '' })).toBe('')
+  })
+
+  it('reports missing values as unset', () => {
+    expect(formatPolicyValue(null)).toBe('Not set')
+    expect(formatPolicyValue(undefined)).toBe('Not set')
+  })
+})
+
+describe('registryPath', () => {
+  it('joins key and value name', () => {
+    expect(registryPath('software\\policies\\x', 'default')).toBe('software\\policies\\x\\default')
+  })
+
+  it('tolerates a trailing separator on the key', () => {
+    expect(registryPath('software\\policies\\x\\', 'default')).toBe('software\\policies\\x\\default')
+  })
+
+  it('falls back when either side is missing', () => {
+    expect(registryPath('software\\policies\\x', '')).toBe('software\\policies\\x')
+    expect(registryPath('', 'default')).toBe('default')
+  })
+})
+
+describe('describeListValueNames', () => {
+  it('describes explicit value names', () => {
+    expect(describeListValueNames({ explicitValue: true })).toBe('Value names are supplied per entry')
+  })
+
+  it('describes generated value names with and without a prefix', () => {
+    expect(describeListValueNames({ valuePrefix: 'Item' })).toBe('Value names are generated: Item1, Item2, ...')
+    expect(describeListValueNames({})).toBe('Value names are generated: 1, 2, ...')
+  })
+})
+
+const ADMX = `<?xml version="1.0" encoding="utf-8"?>
+<policyDefinitions revision="1.0" schemaVersion="1.0">
+  <policyNamespaces>
+    <target prefix="test" namespace="Test.Policies" />
+  </policyNamespaces>
+  <categories><category name="Cat" displayName="$(string.Cat)" /></categories>
+  <policies>
+    <policy name="P" class="User" displayName="$(string.P)" explainText="$(string.P)" key="software\\policies\\parent">
+      <parentCategory ref="Cat" />
+      <enabledList>
+        <item key="software\\policies\\parent" valueName="policyon"><value><decimal value="1" /></value></item>
+      </enabledList>
+      <disabledList>
+        <item key="software\\policies\\parent" valueName="policyon"><value><delete /></value></item>
+      </disabledList>
+      <elements>
+        <text id="t0" key="software\\policies\\child" valueName="default" required="true" expandable="true" />
+      </elements>
+    </policy>
+  </policies>
+</policyDefinitions>`
+
+describe('parseAdmx registry locations', () => {
+  it('keeps an element key that differs from the policy key', async () => {
+    const { policies } = await parseAdmx(ADMX)
+    const elem = policies[0].elements[0]
+    expect(policies[0].key).toBe('software\\policies\\parent')
+    expect(elem.key).toBe('software\\policies\\child')
+    expect(elem.valueName).toBe('default')
+    expect(registryPath(elem.key, elem.valueName)).toBe('software\\policies\\child\\default')
+  })
+
+  it('parses self-closing <delete /> instead of dropping it', async () => {
+    const { policies } = await parseAdmx(ADMX)
+    expect(policies[0].enabledList).toEqual([
+      { key: 'software\\policies\\parent', valueName: 'policyon', value: { type: 'decimal', value: 1 } },
+    ])
+    expect(policies[0].disabledList).toEqual([
+      { key: 'software\\policies\\parent', valueName: 'policyon', value: { type: 'delete' } },
+    ])
+  })
+})

--- a/src/policyFormat.ts
+++ b/src/policyFormat.ts
@@ -1,0 +1,28 @@
+export interface PolicyValueLike { type?: string; value?: string | number }
+
+/** Renders an ADMX <value> node (decimal/string/delete) for display. */
+export function formatPolicyValue(val: PolicyValueLike | null | undefined): string {
+  if (!val) return 'Not set'
+  if (val.type === 'decimal') return String(val.value)
+  if (val.type === 'string') return String(val.value ?? '')
+  if (val.type === 'delete') return 'Delete value'
+  return String(val)
+}
+
+/** Joins a registry key and value name for display, tolerating either being absent. */
+export function registryPath(key: string | undefined | null, valueName: string | undefined | null): string {
+  const k = (key || '').replace(/\\+$/, '')
+  if (!valueName) return k
+  return k ? `${k}\\${valueName}` : valueName
+}
+
+/**
+ * Describes where a <list> element writes its values, since list elements carry no
+ * single valueName: either the user supplies each name (explicitValue) or names are
+ * generated as <valuePrefix>1, <valuePrefix>2, ... under the key.
+ */
+export function describeListValueNames(elem: { explicitValue?: boolean; valuePrefix?: string }): string {
+  if (elem.explicitValue) return 'Value names are supplied per entry'
+  const prefix = elem.valuePrefix || ''
+  return `Value names are generated: ${prefix}1, ${prefix}2, ...`
+}


### PR DESCRIPTION
Fixes #70.

## Problem

ADMX elements can override the policy's registry key and carry their own `valueName`, but the policy page only ever rendered the policy-level `key`. For `L_Defaultfilelocation`:

```xml
<policy name="L_Defaultfilelocation" ... key="software\policies\microsoft\office\16.0\powerpoint\options">
  <elements>
    <text id="L_defaultfilelocation0" key="software\policies\microsoft\office\16.0\powerpoint\recentfolderlist" valueName="default" required="true" expandable="true" />
  </elements>
</policy>
```

the page showed the parent key `...\powerpoint\options` while the value actually lives at `...\powerpoint\recentfolderlist\default` — and the value name wasn't visible anywhere on the page. The data was already parsed and stored; only the display dropped it.

## Changes

**Configuration Elements** now show, per element:
- **Registry Key** — the element's own key, or the policy's key when the element doesn't override one, with a `differs from policy key` badge when it does override
- **Value Name**
- **Required**
- For `list` elements (which have no single value name): whether names are supplied per entry (`explicitValue`) or generated as `<valuePrefix>1, <valuePrefix>2, ...`

These lines and the type-specific details below them share one consistent spacing rhythm.

**Registry writes that were parsed but never displayed** are now shown:
- policy-level `enabledList` / `disabledList` — these were dropped by `admxPolicyLoader` before ever reaching the page, so they're added to the stored entry and rendered under Policy State Values
- boolean elements' `trueList` / `falseList`

**Parser fix**: `<delete />` and `<string />` are self-closing, so xml2js parses them to `''`. `parseValue` tested truthiness, so both were silently dropped — a `disabledList` delete rendered as "Not set" rather than "Delete value". It now tests for presence, and also accepts `longDecimal` values.

New `src/policyFormat.ts` holds the value/path formatters shared by the page and the new `RegistryValues.astro` component, replacing the page's inline `fmtVal`.

## Also: build-preview instructions

The preview comment told reviewers they could open `index.html` from the downloaded `dist` artifact. That can't work, and fails noisily — `ERR_FILE_NOT_FOUND` on every asset plus CORS errors on every island. Three independent reasons:

1. The build emits root-absolute URLs (`/_astro/...`, `/data/...`), which resolve against the filesystem root under `file://` (`file:///C:/_astro/...`).
2. Hydration goes through ES modules, and module scripts are blocked from a `file://` null origin.
3. The sidebar and search `fetch('/data/*.json')` at runtime — also blocked over `file://`.

The comment now points at an HTTP server instead.

## Verification

`pnpm test` — 22 passing, including new unit tests for the formatters and for the `<delete />` parse. `tsc --noEmit` reports the same 10 pre-existing errors as `master`, none in the changed files. (`astro check` fails at startup in this environment with an unrelated language-server/TS error, on `master` too.)

Rendered against the real ADMX set via the dev server:

| Policy | What it exercises |
|---|---|
| `ppt16 / L_Defaultfilelocation` | the issue — `Registry Key: ...\powerpoint\recentfolderlist` *(differs from policy key)*, `Value Name: default` |
| `ppt16 / L_SaveAutoRecoverinfo` | elements with no key of their own inherit the policy key, with no badge |
| `AddMSFTHard / Pol_SecGuide_0301_RemoveRunasdifferentuser` | 5 enabled writes across 5 keys; 5 disabled writes all `Delete value` |
| `AddSystemHard / AuthenticodeCertVerification` | list items that omit `key` fall back to the policy key |
| `AddNetworkHard / SSLv3` | boolean True/False writes for both `Enabled` and `DisabledByDefault` |
| `Microsoft.WSL / WSLContainerRegistryAllowlist` | list value names generated as `AllowedRegistry1, AllowedRegistry2, ...` |
| `ActiveXInstallService / ApprovedActiveXInstallSites` | `explicitValue` list, alongside scalar enabled/disabled values |

The workflow change was verified by executing the step's script and rendering the `github-script` comment body locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016G5JNoSySmnd98RM4TPago
